### PR TITLE
Implement self-evolving features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+run.log
+RecursiveAI_mutated.py

--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ belief and a truth score, analyzes its own source, rewrites itself with a
 modified belief, records each cycle in a semantic tree, then trains a tiny
 character-level RNN on the collected traces. Each run can optionally commit the
 updated code to Git via `save_version()`.
+
+## Updates
+
+- Each `SemanticNode` now records a SHA256 hash of the source code used in that
+  cycle for provenance.
+- During `evolve()` the class writes a mutated version of itself to
+  `RecursiveAI_mutated.py` and spawns it with `subprocess` to demonstrate a
+  self-reloading runtime.
+- The training step now attempts to use `sentence-transformers` to embed belief
+  histories instead of the previous toy RNN.


### PR DESCRIPTION
## Summary
- track source code hash in `SemanticNode`
- mutate reasoning text and write mutated file when evolving
- use sentence-transformers embeddings instead of toy RNN
- spawn mutated version after training
- document new features and add ignore rules

## Testing
- `python -m py_compile recursive_ai.py`
- `pip install torch sentence-transformers --quiet`
- `python recursive_ai.py | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68404d7a1b348328a16b54ea824ae7ee